### PR TITLE
Fix deps vulns

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -42,6 +42,16 @@
   },
   "packageRules": [
     {
+      "description": "Pin Python to 3.12.x - asyncpg not compatible with 3.13+",
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "python"
+      ],
+      "allowedVersions": "3.12"
+    },
+    {
       "description": "Group Docker base images",
       "matchDatasources": [
         "docker"


### PR DESCRIPTION
Fix some deps vulns and pin Python 3.12 in renovate for now because asyncpg isn't ready for 3.13+