### PR TITLE
fix(ci): replace deprecated semgrep-action input with direct CLI

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -24,15 +24,22 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Run Semgrep
-        uses: semgrep/semgrep-action@v1
+      - name: Set up Python
+        uses: actions/setup-python@v6
         with:
-          config: >-
-            p/security-audit
-            p/owasp-top-ten
-            p/python
-            p/dockerfile
-          generateSarif: true
+          python-version: '3.12'
+
+      - name: Install Semgrep
+        run: pip install --upgrade semgrep
+
+      - name: Run Semgrep
+        run: |
+          semgrep scan \
+            --config=p/security-audit \
+            --config=p/owasp-top-ten \
+            --config=p/python \
+            --config=p/dockerfile \
+            --sarif --output=semgrep.sarif
 
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@v4


### PR DESCRIPTION
## Summary

The latest `Security Scanning` run failed at the **Semgrep SAST** job with:

> Unexpected input(s) 'generateSarif', valid inputs are ['entryPoint', 'args', 'config', 'publishToken']

`semgrep/semgrep-action@v1` removed the `generateSarif` input. Switch to installing semgrep via pip and invoking the CLI directly — `--config=...` flags can be repeated for the same rulesets we used before, and `--sarif --output=semgrep.sarif` produces the file the existing upload step expects.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — workflow YAML still parses.
- [x] Locally: `pip install semgrep && semgrep scan --config=... --sarif --output=...` exits 0 and produces a valid SARIF file (validated `runs[0].tool.driver.rules`/`results`).
- [ ] CI Semgrep SAST job runs to completion and uploads SARIF.

---
_Generated by [Claude Code](https://claude.ai/code/session_016r8GJkKHePb3KXNUm2tdp7)_