### PR TITLE
docs: wrap overlong CLAUDE.md line — fixes Markdown Linting failure from #34

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,5 +86,7 @@ ForeFlight CSV is the primary import source - preserve all columns during import
 
 - Commit style: `fix:`, `feat:`, `chore(deps):` etc. Co-Authored-By tags for AI-assisted commits are expected.
 - Branch naming: `feature/v{version}-description`, `fix/v{version}-description`
-- PRs go `feature-branch` -> `develop` -> `main`; the repo blocks merge commits on `main`, so release PRs squash — after each promotion, back-merge `main` into `develop` (content-neutral, `-s ours` from develop) or the next promotion hits phantom conflicts; force pushes to `main`/`develop` require explicit confirmation
+- PRs go `feature-branch` -> `develop` -> `main`; the repo blocks merge commits on `main`, so release PRs squash —
+  after each promotion, back-merge `main` into `develop` (content-neutral, `-s ours` from develop) or the next
+  promotion hits phantom conflicts; force pushes to `main`/`develop` require explicit confirmation
 - Renovate handles dependency PRs (scheduled Mondays before 6am ET)


### PR DESCRIPTION
The one-line CLAUDE.md edit in #34 was 322 chars — over the repo's MD013 limit of 160 — which turned the Markdown Linting check red on that PR and on `develop`. Wrapped to three lines; `markdownlint` (repo config, v0.42.0) verified clean locally this time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HXHbMScMMCnW5u6ktQFrnV

---
_Generated by [Claude Code](https://claude.ai/code/session_01HXHbMScMMCnW5u6ktQFrnV)_