### PR TITLE
Revive TrueHour: patch dependencies and record FATH tracking

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,7 @@ posture: `wiki/Product-Notes.md` — read it before writing user-facing copy.
 
 **Stack**: FastAPI (Python 3.12) + React 19 (TypeScript) + PostgreSQL 18 + Docker
 **Repo**: Consolidated monorepo (backend, frontend-react, infrastructure)
+**Tracking**: Work for this repo is ticketed in the `FATH` project in It's a Plan.
 
 ## Critical Constraints
 

--- a/backend/requirements-test.txt
+++ b/backend/requirements-test.txt
@@ -1,4 +1,4 @@
-pytest==8.4.2
-pytest-asyncio==0.26.0
-pytest-cov==6.3.0
+pytest==9.1.1
+pytest-asyncio==1.4.0
+pytest-cov==7.1.0
 httpx==0.28.1

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,7 +1,7 @@
-fastapi==0.136.0
-uvicorn[standard]==0.46.0
-pydantic==2.13.3
+fastapi==0.141.1
+uvicorn[standard]==0.52.4
+pydantic==2.13.4
 httpx==0.28.1
 asyncpg==0.31.0
-python-dotenv==1.2.2
-python-multipart==0.0.31
+python-dotenv==1.2.3
+python-multipart==0.0.32

--- a/frontend-react/package-lock.json
+++ b/frontend-react/package-lock.json
@@ -2325,9 +2325,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2645,9 +2645,9 @@
       "peer": true
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.14.tgz",
+      "integrity": "sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optional": true,
       "optionalDependencies": {
@@ -3943,9 +3943,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Tickets: FATH-1, FATH-2, FATH-3, FATH-4

Brings TrueHour back to a fully patched dependency state after the idle period. Four independently revertible commits.

## Security fixes

**Three npm advisories** (FATH-2) — lockfile-only, `package.json` untouched:

| Advisory | Severity | Path | Ships to users? |
| --- | --- | --- | --- |
| GHSA-55q2-fjhq-7xh7 (DOMPurify XSS) | moderate | `jspdf` → `dompurify` 3.4.12 → 3.4.14 | **Yes** — `jspdf` is a runtime dep |
| GHSA-rgw5-rvv9-x895 (brace-expansion DoS) | high | `eslint` → `minimatch` → `brace-expansion` 5.0.8 → 5.0.9 | No — lint tooling |
| GHSA-2v37-7h3g-55p8 (nanoid loop) | high | `vite` → `postcss` → `nanoid` 3.3.16 → 3.3.18 | No — build tooling |

The severity ranking is inverted from what it looks like: the only advisory reaching users is the *moderate* one, because `jspdf` ships in the bundle.

**PYSEC-2026-1845** (FATH-3) — `pytest` 8.4.2 → 9.1.1, with `pytest-asyncio` 0.26.0 → 1.4.0 and `pytest-cov` 6.3.0 → 7.1.0 (0.26 doesn't support pytest 9). Test-only; nothing here reaches a running container.

## Routine currency

**Backend runtime** (FATH-4): `fastapi` 0.136.0 → 0.141.1, `uvicorn[standard]` 0.46.0 → 0.52.4, `pydantic` 2.13.3 → 2.13.4, `python-dotenv` 1.2.2 → 1.2.3, `python-multipart` 0.0.31 → 0.0.32. No CVEs in this set. FastAPI and Uvicorn move together per the repo constraint; both are pre-1.0 so the minors were validated rather than assumed. Python stays on 3.12, `asyncpg` stays at 0.31.0.

**Docs** (FATH-1): one line in `CLAUDE.md` recording that this repo's work is ticketed in the `FATH` project.

## Testing

Locally, on Python 3.12.3 / Node 22.22.2, against the actual repo files:

- Backend: **112 passed** (unit + integration) — same count as the pre-change baseline
- Frontend: **37 passed** across 3 files; `npm run build` and `npm run lint` clean
- `pip-audit -r requirements.txt -r requirements-test.txt` → no known vulnerabilities
- `npm audit` → 0 vulnerabilities
- App imports and `GET /api/v1/health` returns 200 (`degraded`, correctly, with no Postgres attached)

A baseline was captured before any change (backend 112, frontend 37, build clean) so the post-change numbers are a comparison, not an assertion.

In CI on this head, **31 checks, 29 success, 0 failures** (the 2 skips are release-only SBOM publish/attest jobs). Notably, **both Docker images build**: the `Trivy Container Scan` matrix runs `docker build` on `backend/Dockerfile` and `infrastructure/Dockerfile.frontend-react` before scanning, and both passed with no CRITICAL/HIGH findings in the built images.

## Not validated here

**A real `docker compose up`.** Image build is confirmed by CI, but that is not the same as the three-container stack running together — the API reaching Postgres, `db_migrations.py` executing against a live database, nginx serving the frontend, and health reporting something other than `degraded`. That needs one run on a machine with Docker; the remote session container has no Docker daemon.

## Note on scope

The branch already carried the FATH-1 docs commit with green CI. Rather than open a second PR from the same branch, the dependency work landed here and this PR was retitled. Happy to split if you'd rather merge the docs line separately.