### PR TITLE
feat(budget): report spend the budget view does not count

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -313,6 +313,47 @@ class CategoryBudgetSummary(BaseModel):
     card_count: int
 
 
+class UncountedExpense(BaseModel):
+    """An expense that no budget card counts."""
+
+    id: int
+    date: date
+    category: str
+    subcategory: Optional[str] = None
+    description: Optional[str] = None
+    vendor: Optional[str] = None
+    amount: Decimal
+    aircraft_id: Optional[int] = None
+
+
+class FlightCostBreakdown(BaseModel):
+    """Flight cost columns, which budget cards do not read."""
+
+    fuel_cost: Decimal
+    landing_fees: Decimal
+    instructor_cost: Decimal
+    rental_cost: Decimal
+    other_costs: Decimal
+
+
+class UncountedSpendSummary(BaseModel):
+    """Recorded spend that budget card actuals do not include.
+
+    Card actuals sum expense_budget_links.amount, so unlinked expenses count
+    against nothing, and flight cost columns are never read. Reported as
+    separate figures because they are separate problems.
+    """
+
+    unlinked_expense_count: int
+    unlinked_expense_total: Decimal
+    unlinked_expenses: List[UncountedExpense]
+    partially_linked_expense_count: int
+    partially_linked_shortfall: Decimal
+    flight_cost_count: int
+    flight_cost_total: Decimal
+    flight_cost_breakdown: FlightCostBreakdown
+
+
 class AnnualBudgetSummary(BaseModel):
     """Annual budget summary."""
 

--- a/backend/app/postgres_database.py
+++ b/backend/app/postgres_database.py
@@ -1135,6 +1135,94 @@ class PostgresDatabase:
             "by_category": by_category,
         }
 
+    async def get_uncounted_spend(self) -> Dict[str, Any]:
+        """Report recorded spend that no budget card counts.
+
+        Budget card actuals are the sum of expense_budget_links.amount, so an
+        expense with no link row contributes to no budget. Flight cost columns
+        are not read by the budget card system at all. Both are real money the
+        budget view is blind to; they are reported separately because they are
+        different problems with different fixes.
+        """
+        async with self.acquire() as conn:
+            unlinked_totals = await conn.fetchrow(
+                """
+                SELECT COUNT(*) AS expense_count,
+                       COALESCE(SUM(e.amount), 0) AS total
+                FROM expenses e
+                LEFT JOIN expense_budget_links ebl ON ebl.expense_id = e.id
+                WHERE ebl.id IS NULL
+                """
+            )
+
+            unlinked_rows = await conn.fetch(
+                """
+                SELECT e.id, e.date, e.category, e.subcategory, e.description,
+                       e.vendor, e.amount, e.aircraft_id
+                FROM expenses e
+                LEFT JOIN expense_budget_links ebl ON ebl.expense_id = e.id
+                WHERE ebl.id IS NULL
+                ORDER BY e.date DESC, e.id DESC
+                """
+            )
+
+            # Partially allocated: linked, but the links do not cover the full
+            # expense. The shortfall counts against no budget either.
+            partial = await conn.fetchrow(
+                """
+                SELECT COUNT(*) AS expense_count,
+                       COALESCE(SUM(shortfall), 0) AS total
+                FROM (
+                    SELECT e.amount - SUM(ebl.amount) AS shortfall
+                    FROM expenses e
+                    JOIN expense_budget_links ebl ON ebl.expense_id = e.id
+                    GROUP BY e.id, e.amount
+                    HAVING e.amount - SUM(ebl.amount) > 0
+                ) gaps
+                """
+            )
+
+            flight_costs = await conn.fetchrow(
+                """
+                SELECT COUNT(*) FILTER (
+                           WHERE COALESCE(fuel_cost, 0) + COALESCE(landing_fees, 0)
+                               + COALESCE(instructor_cost, 0) + COALESCE(rental_cost, 0)
+                               + COALESCE(other_costs, 0) > 0
+                       ) AS flight_count,
+                       COALESCE(SUM(COALESCE(fuel_cost, 0)), 0) AS fuel_cost,
+                       COALESCE(SUM(COALESCE(landing_fees, 0)), 0) AS landing_fees,
+                       COALESCE(SUM(COALESCE(instructor_cost, 0)), 0) AS instructor_cost,
+                       COALESCE(SUM(COALESCE(rental_cost, 0)), 0) AS rental_cost,
+                       COALESCE(SUM(COALESCE(other_costs, 0)), 0) AS other_costs
+                FROM flights
+                """
+            )
+
+            flight_total = (
+                flight_costs["fuel_cost"]
+                + flight_costs["landing_fees"]
+                + flight_costs["instructor_cost"]
+                + flight_costs["rental_cost"]
+                + flight_costs["other_costs"]
+            )
+
+            return {
+                "unlinked_expense_count": unlinked_totals["expense_count"],
+                "unlinked_expense_total": unlinked_totals["total"],
+                "unlinked_expenses": [dict(r) for r in unlinked_rows],
+                "partially_linked_expense_count": partial["expense_count"],
+                "partially_linked_shortfall": partial["total"],
+                "flight_cost_count": flight_costs["flight_count"],
+                "flight_cost_total": flight_total,
+                "flight_cost_breakdown": {
+                    "fuel_cost": flight_costs["fuel_cost"],
+                    "landing_fees": flight_costs["landing_fees"],
+                    "instructor_cost": flight_costs["instructor_cost"],
+                    "rental_cost": flight_costs["rental_cost"],
+                    "other_costs": flight_costs["other_costs"],
+                },
+            }
+
     # Expense-Budget Card Links
 
     async def create_expense_budget_link(self, data: Dict[str, Any]) -> int:

--- a/backend/app/routers/budget_cards.py
+++ b/backend/app/routers/budget_cards.py
@@ -12,6 +12,7 @@ from app.models import (
     CategoryBudgetSummary,
     ExpenseBudgetLinkResponse,
     MonthlyBudgetSummary,
+    UncountedSpendSummary,
 )
 from app.postgres_database import postgres_db
 from fastapi import APIRouter, HTTPException, Query
@@ -156,6 +157,21 @@ async def get_annual_summary(year: int = Query(..., description="Year to summari
     try:
         summary = await postgres_db.get_annual_budget_summary(year)
         return summary
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.get("/summary/uncounted", response_model=UncountedSpendSummary)
+async def get_uncounted_spend():
+    """Report recorded spend that budget card actuals do not include.
+
+    Card actuals are the sum of expense_budget_links.amount, so an expense with
+    no link counts against no budget, and flight cost columns are never read.
+    Both are reported separately: an unlinked expense is fixed by linking it,
+    while flight costs are a modelling question, not a missing link.
+    """
+    try:
+        return await postgres_db.get_uncounted_spend()
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 

--- a/backend/tests/integration/test_api_uncounted_spend.py
+++ b/backend/tests/integration/test_api_uncounted_spend.py
@@ -1,0 +1,121 @@
+"""Integration tests for the uncounted-spend budget endpoint.
+
+Budget card actuals sum expense_budget_links.amount, so an expense with no
+link counts against no budget, and flight cost columns are never read at all.
+This endpoint reports both so the budget view can stop implying its totals are
+complete.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+EMPTY = {
+    "unlinked_expense_count": 0,
+    "unlinked_expense_total": "0.00",
+    "unlinked_expenses": [],
+    "partially_linked_expense_count": 0,
+    "partially_linked_shortfall": "0.00",
+    "flight_cost_count": 0,
+    "flight_cost_total": "0.00",
+    "flight_cost_breakdown": {
+        "fuel_cost": "0.00",
+        "landing_fees": "0.00",
+        "instructor_cost": "0.00",
+        "rental_cost": "0.00",
+        "other_costs": "0.00",
+    },
+}
+
+WITH_GAPS = {
+    **EMPTY,
+    "unlinked_expense_count": 2,
+    "unlinked_expense_total": "412.75",
+    "unlinked_expenses": [
+        {
+            "id": 7,
+            "date": "2026-08-01",
+            "category": "Fuel",
+            "subcategory": None,
+            "description": "Avgas",
+            "vendor": "Signature KPWK",
+            "amount": "312.75",
+            "aircraft_id": 3,
+        },
+        {
+            "id": 9,
+            "date": "2026-08-14",
+            "category": "Maintenance",
+            "subcategory": None,
+            "description": None,
+            "vendor": None,
+            "amount": "100.00",
+            "aircraft_id": None,
+        },
+    ],
+    "partially_linked_expense_count": 1,
+    "partially_linked_shortfall": "40.00",
+    "flight_cost_count": 5,
+    "flight_cost_total": "980.00",
+    "flight_cost_breakdown": {
+        "fuel_cost": "600.00",
+        "landing_fees": "30.00",
+        "instructor_cost": "300.00",
+        "rental_cost": "0.00",
+        "other_costs": "50.00",
+    },
+}
+
+ENDPOINT = "/api/user/budget-cards/summary/uncounted"
+TARGET = "app.postgres_database.postgres_db.get_uncounted_spend"
+
+
+def test_uncounted_spend_reports_zero_when_everything_is_linked(client):
+    """A clean ledger reports explicit zeros rather than omitting the figures."""
+    with patch(TARGET, AsyncMock(return_value=EMPTY)):
+        response = client.get(ENDPOINT)
+    assert response.status_code == 200
+    body = response.json()
+    assert body["unlinked_expense_count"] == 0
+    assert float(body["unlinked_expense_total"]) == 0
+    assert body["unlinked_expenses"] == []
+    assert float(body["flight_cost_total"]) == 0
+
+
+def test_uncounted_spend_reports_unlinked_expenses(client):
+    """Unlinked expenses are returned with the rows, not just a total."""
+    with patch(TARGET, AsyncMock(return_value=WITH_GAPS)):
+        response = client.get(ENDPOINT)
+    assert response.status_code == 200
+    body = response.json()
+    assert body["unlinked_expense_count"] == 2
+    assert float(body["unlinked_expense_total"]) == 412.75
+    assert len(body["unlinked_expenses"]) == 2
+    assert body["unlinked_expenses"][0]["vendor"] == "Signature KPWK"
+
+
+def test_flight_costs_reported_separately_from_unlinked_expenses(client):
+    """The two gaps must not be blended - they have different remedies.
+
+    An unlinked expense is fixed by linking it. Flight cost columns are a
+    modelling question, so the figures stay distinct and the breakdown is
+    itemised.
+    """
+    with patch(TARGET, AsyncMock(return_value=WITH_GAPS)):
+        response = client.get(ENDPOINT)
+    body = response.json()
+    assert float(body["flight_cost_total"]) == 980.00
+    assert float(body["unlinked_expense_total"]) == 412.75
+    assert float(body["flight_cost_total"]) != float(body["unlinked_expense_total"])
+    breakdown = body["flight_cost_breakdown"]
+    assert float(breakdown["fuel_cost"]) == 600.00
+    assert float(breakdown["instructor_cost"]) == 300.00
+    # The breakdown must account for the whole total, or the number is a lie.
+    assert sum(float(v) for v in breakdown.values()) == float(body["flight_cost_total"])
+
+
+def test_partially_linked_shortfall_is_reported(client):
+    """An expense whose links do not cover its full amount leaves a shortfall."""
+    with patch(TARGET, AsyncMock(return_value=WITH_GAPS)):
+        response = client.get(ENDPOINT)
+    body = response.json()
+    assert body["partially_linked_expense_count"] == 1
+    assert float(body["partially_linked_shortfall"]) == 40.00


### PR DESCRIPTION
Ticket: FATH-10 (backend half — the UI is still to come)

## The problem

Budget card `actual_amount` is computed as `SUM(expense_budget_links.amount)` — the **link** amount, not `expenses.amount`:

```sql
SELECT bc.*,
    COALESCE(SUM(ebl.amount), 0) as actual_amount,
    bc.budgeted_amount - COALESCE(SUM(ebl.amount), 0) as remaining_amount
FROM budget_cards bc
LEFT JOIN expense_budget_links ebl ON bc.id = ebl.budget_card_id
```

So an expense with no link row counts against **no budget at all**. It shows in the expenses list, feeds `/api/user/expenses/summary`, and is absent from every budget figure. Linking is optional on every write path — `CreateExpenseModal` links only if a card was picked, and CSV import links only when the row carried a `budget_card_id`.

Separately, `flights` carries `fuel_cost`, `landing_fees`, `instructor_cost`, `rental_cost`, `other_costs`. The budget-card system never reads them; only the deprecated `budgets` endpoint sums them.

Both gaps push reported actuals **below** true spend, so the budget view reads healthier than the bank account.

## What this adds

`GET /api/user/budget-cards/summary/uncounted`:

- **Unlinked expenses** — count, total, and the rows themselves, so the UI can offer to link them rather than just report a number
- **Partially linked expenses** — where links exist but don't cover the full expense amount, the shortfall counts against no budget either
- **Flight cost totals**, itemised by column, as a **separate** figure

The two gaps are deliberately kept distinct. An unlinked expense is fixed by linking it. Flight costs are a modelling question — should they become expenses at all? Blending them into one number would imply a single remedy that doesn't exist.

Surfacing only. What `actual_amount` counts is unchanged.

## Testing

- **116 passed** (112 baseline + 4 new), backend unit + integration
- black 24.10.0, isort 5.13.2, flake8 7.1.1 — the versions pinned in `.pre-commit-config.yaml` — all clean

One caveat worth stating plainly: **the test suite mocks Postgres entirely** (`tests/conftest.py` patches `postgres_db.connect`), so no test executes the SQL in this PR. The new tests exercise the endpoint contract and the response shape, not the queries. To get some real assurance I parsed all four statements with `pglast` (libpg_query — the actual Postgres grammar); all four parse. That validates syntax, not that the joins return what I think they do.

Given this repo has now shipped two bugs in files no test executes, that gap seems worth naming rather than glossing.

## Still to come on FATH-10

The budget view UI — surfacing these figures next to the totals they contradict, and letting an unlinked expense be linked to a card without leaving the page (reusing the existing `link-expense` endpoint and `expenseStore.linkToBudgetCard`).

Note `@tanstack/react-query` is a dependency with **zero usages** in `src/` — the frontend is Zustand + plain `fetch` throughout, and the UI half will follow that rather than introduce a second data-fetching pattern.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PTLxEk6B6Dtixc7MaNgM34)_